### PR TITLE
kubeconfig: support proxy URL definition

### DIFF
--- a/controlplane/controllers/kthreescontrolplane_controller.go
+++ b/controlplane/controllers/kthreescontrolplane_controller.go
@@ -648,6 +648,7 @@ func (r *KThreesControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 			clusterName,
 			endpoint.String(),
 			controllerOwnerRef,
+			nil,
 		)
 		if errors.Is(createErr, kubeconfig.ErrDependentCertificateNotFound) {
 			return ctrl.Result{RequeueAfter: dependentCertRequeueAfter}, nil

--- a/controlplane/controllers/kthreescontrolplane_controller.go
+++ b/controlplane/controllers/kthreescontrolplane_controller.go
@@ -648,7 +648,6 @@ func (r *KThreesControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 			clusterName,
 			endpoint.String(),
 			controllerOwnerRef,
-			nil,
 		)
 		if errors.Is(createErr, kubeconfig.ErrDependentCertificateNotFound) {
 			return ctrl.Result{RequeueAfter: dependentCertRequeueAfter}, nil

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -128,7 +128,7 @@ func New(clusterName, endpoint string, clientCACert *x509.Certificate, clientCAK
 }
 
 // CreateSecret creates the Kubeconfig secret for the given cluster.
-func CreateSecret(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, proxyURL *string) error {
+func CreateSecret(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) error {
 	name := util.ObjectKey(cluster)
 	return CreateSecretWithOwner(
 		ctx,
@@ -141,14 +141,13 @@ func CreateSecret(ctx context.Context, c client.Client, cluster *clusterv1.Clust
 			Name:       cluster.Name,
 			UID:        cluster.UID,
 		},
-		proxyURL,
 	)
 }
 
 // CreateSecretWithOwner creates the Kubeconfig secret for the given cluster name, namespace, endpoint, owner reference and proxy URL.
-func CreateSecretWithOwner(ctx context.Context, c client.Client, clusterName client.ObjectKey, endpoint string, owner metav1.OwnerReference, proxyURL *string) error {
+func CreateSecretWithOwner(ctx context.Context, c client.Client, clusterName client.ObjectKey, endpoint string, owner metav1.OwnerReference) error {
 	server := fmt.Sprintf("https://%s", endpoint)
-	out, err := generateKubeconfig(ctx, c, clusterName, server, proxyURL)
+	out, err := generateKubeconfig(ctx, c, clusterName, server, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The implementations out for review are used to support proxy URL definition via kubeconfig.